### PR TITLE
NSEW labels and constellations setup

### DIFF
--- a/src/BlazeStarNova.vue
+++ b/src/BlazeStarNova.vue
@@ -188,7 +188,7 @@ import { BackgroundImageset, skyBackgroundImagesets, supportsTouchscreen, blurAc
 import { createHorizon, removeHorizon } from "./horizon";
 import { LocationRad } from "./types";
 import { Annotation2 } from "./Annotation2";
-import { initializeConstellationNames, makeAltAzGridText } from "./wwt-hacks";
+import { initializeConstellationNames, makeAltAzGridText, setupConstellationFigures } from "./wwt-hacks";
 
 
 type SheetType = "text" | "video";
@@ -243,6 +243,7 @@ onMounted(() => {
     store.applySetting(["showAltAzGridText", showAltAzGrid.value]);
     store.applySetting(["altAzGridColor", Color.fromArgb(180, 133, 201, 254)]);
     store.applySetting(["showConstellationLabels", true]);
+    store.applySetting(["showConstellationFigures", true]);
     updateHorizon(showHorizon.value);
 
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
@@ -269,6 +270,8 @@ onMounted(() => {
       Annotation2.drawBatch(this.renderContext);
     }
     WWTControl.singleton.renderOneFrame = renderOneFrame.bind(WWTControl.singleton);
+    WWTControl.singleton.renderOneFrame();
+    setupConstellationFigures();
 
     // We want to make sure that the location change happens AFTER
     // the camera reposition caused by local horizon mode.

--- a/src/BlazeStarNova.vue
+++ b/src/BlazeStarNova.vue
@@ -68,6 +68,8 @@
               label="Sky Grid" hide-details />
             <v-checkbox :color="accentColor" v-model="showHorizon" @keyup.enter="showHorizon = !showHorizon"
               label="Horizon" hide-details />
+            <v-checkbox :color="accentColor" v-model="showConstellations" @keyup.enter="showConstellations = !showConstellations"
+              label="Constellations" hide-details />
           </div>
         </div>
       </div>
@@ -228,6 +230,7 @@ const tab = ref(0);
 const showHorizon = ref(true);
 const showAltAzGrid = ref(true);
 const showControls = ref(false);
+const showConstellations = ref(true);
 
 onMounted(() => {
   store.waitForReady().then(async () => {
@@ -242,8 +245,8 @@ onMounted(() => {
     store.applySetting(["showAltAzGrid", showAltAzGrid.value]);
     store.applySetting(["showAltAzGridText", showAltAzGrid.value]);
     store.applySetting(["altAzGridColor", Color.fromArgb(180, 133, 201, 254)]);
-    store.applySetting(["showConstellationLabels", true]);
-    store.applySetting(["showConstellationFigures", true]);
+    store.applySetting(["showConstellationLabels", showConstellations.value]);
+    store.applySetting(["showConstellationFigures", showConstellations.value]);
     updateHorizon(showHorizon.value);
 
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
@@ -368,6 +371,10 @@ function updateHorizon(show: boolean) {
 watch(showHorizon, updateHorizon);
 watch(showAltAzGrid, (show) => {
   store.applySetting(["showAltAzGrid", show]);
+});
+watch(showConstellations, (show) => {
+  store.applySetting(["showConstellationLabels", show]);
+  store.applySetting(["showConstellationFigures", show]);
 });
 </script>
 

--- a/src/BlazeStarNova.vue
+++ b/src/BlazeStarNova.vue
@@ -188,7 +188,7 @@ import { BackgroundImageset, skyBackgroundImagesets, supportsTouchscreen, blurAc
 import { createHorizon, removeHorizon } from "./horizon";
 import { LocationRad } from "./types";
 import { Annotation2 } from "./Annotation2";
-import { makeAltAzGridText } from "./wwt-hacks";
+import { initializeConstellationNames, makeAltAzGridText } from "./wwt-hacks";
 
 
 type SheetType = "text" | "video";
@@ -236,10 +236,13 @@ onMounted(() => {
     // If there are layers to set up, do that here!
     layersLoaded.value = true;
 
+    initializeConstellationNames();
+
     store.applySetting(["localHorizonMode", true]);
     store.applySetting(["showAltAzGrid", showAltAzGrid.value]);
     store.applySetting(["showAltAzGridText", showAltAzGrid.value]);
     store.applySetting(["altAzGridColor", Color.fromArgb(180, 133, 201, 254)]);
+    store.applySetting(["showConstellationLabels", true]);
     updateHorizon(showHorizon.value);
 
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment

--- a/src/BlazeStarNova.vue
+++ b/src/BlazeStarNova.vue
@@ -234,7 +234,6 @@ const showConstellations = ref(true);
 
 onMounted(() => {
   store.waitForReady().then(async () => {
-    console.log(store);
     skyBackgroundImagesets.forEach(iset => backgroundImagesets.push(iset));
 
     // If there are layers to set up, do that here!

--- a/src/BlazeStarNova.vue
+++ b/src/BlazeStarNova.vue
@@ -213,7 +213,7 @@ const props = withDefaults(defineProps<MainComponentProps>(), {
     return {
       raRad: 4.001238944138198,
       decRad: 0.5307600894728279,
-      zoomDeg: 60
+      zoomDeg: 180
     };
   }
 });

--- a/src/BlazeStarNova.vue
+++ b/src/BlazeStarNova.vue
@@ -211,8 +211,8 @@ const props = withDefaults(defineProps<MainComponentProps>(), {
   wwtNamespace: "MainComponent",
   initialCameraParams: () => {
     return {
-      raRad: (15 + 59 / 60 + 30.1622 / 3600) * (12 / Math.PI),
-      decRad: (25 + 55 / 60 + 12.613 / 3600) * D2R,
+      raRad: 4.001238944138198,
+      decRad: 0.5307600894728279,
       zoomDeg: 60
     };
   }
@@ -234,6 +234,7 @@ const showConstellations = ref(true);
 
 onMounted(() => {
   store.waitForReady().then(async () => {
+    console.log(store);
     skyBackgroundImagesets.forEach(iset => backgroundImagesets.push(iset));
 
     // If there are layers to set up, do that here!

--- a/src/BlazeStarNova.vue
+++ b/src/BlazeStarNova.vue
@@ -238,6 +238,7 @@ onMounted(() => {
 
     store.applySetting(["localHorizonMode", true]);
     store.applySetting(["showAltAzGrid", showAltAzGrid.value]);
+    store.applySetting(["showAltAzGridText", showAltAzGrid.value]);
     store.applySetting(["altAzGridColor", Color.fromArgb(180, 133, 201, 254)]);
     updateHorizon(showHorizon.value);
 

--- a/src/wwt-hacks.ts
+++ b/src/wwt-hacks.ts
@@ -3,7 +3,7 @@
 
 /* eslint-disable */
 
-import { Grids, SpaceTimeController, Text3d, Text3dBatch, Vector3d } from "@wwtelescope/engine";
+import { Constellations, Coordinates, Grids, Settings, SpaceTimeController, Text3d, Text3dBatch, Vector3d } from "@wwtelescope/engine";
 
 export function makeAltAzGridText() {
   if (Grids._altAzTextBatch == null) {
@@ -22,5 +22,28 @@ export function makeAltAzGridText() {
     directions.forEach(([v, text]) => {
       Grids._altAzTextBatch.add(new Text3d(Vector3d.create(...v), up, text, 75, 0.00018));
     });
+  }
+}
+
+export function initializeConstellationNames() {
+  if (Constellations.constellationCentroids == null) {
+      return;
+  }
+  Constellations._namesBatch = new Text3dBatch(Settings.get_active().get_constellationLabelsHeight());
+  const keep = ["BOO", "CRB"];
+  for (const constellation of Object.keys(Constellations.constellationCentroids)) {
+      
+      if (!keep.includes(constellation)) {
+        continue;
+      }
+
+      const centroid = Constellations.constellationCentroids[constellation];
+      const center = Coordinates.raDecTo3dAu(centroid.get_RA(), centroid.get_dec(), 1);
+      const up = Vector3d.create(0, 1, 0);
+      const name = centroid.get_name();
+      if (centroid.get_name() === 'Triangulum Australe') {
+          name = ss.replaceString(name, ' ', '\n   ');
+      }
+      Constellations._namesBatch.add(new Text3d(center, up, name, Settings.get_active().get_constellationLabelsHeight(), 0.000125));
   }
 }

--- a/src/wwt-hacks.ts
+++ b/src/wwt-hacks.ts
@@ -3,7 +3,7 @@
 
 /* eslint-disable */
 
-import { Constellations, Coordinates, Grids, Settings, SpaceTimeController, Text3d, Text3dBatch, Vector3d } from "@wwtelescope/engine";
+import { Constellations, Coordinates, Grids, Settings, SpaceTimeController, Text3d, Text3dBatch, Vector3d, WWTControl } from "@wwtelescope/engine";
 
 export function makeAltAzGridText() {
   if (Grids._altAzTextBatch == null) {
@@ -46,4 +46,32 @@ export function initializeConstellationNames() {
       }
       Constellations._namesBatch.add(new Text3d(center, up, name, Settings.get_active().get_constellationLabelsHeight(), 0.000125));
   }
+}
+
+export function setupConstellationFigures() {
+  WWTControl.constellationsFigures.draw = function (renderContext, showOnlySelected, focusConstellation, clearExisting) {
+    const keep = ["BOO", "CRB"];
+    Constellations._maxSeperation = Math.max(0.6, Math.cos((renderContext.get_fovAngle() * 2) / 180 * Math.PI));
+    this._drawCount = 0;
+    var lsSelected = null;
+    if (this.lines == null || Constellations.constellationCentroids == null) {
+        return;
+    }
+    Constellations._constToDraw = focusConstellation;
+    for (const ls of this.lines) {
+        const name = ls.get_name();
+        if (!keep.includes(name)) {
+          continue;
+        }
+        if (Constellations._constToDraw === name && this._boundry) {
+            lsSelected = ls;
+        }
+        else if (!showOnlySelected || !this._boundry) {
+            this._drawSingleConstellation(renderContext, ls, 1);
+        }
+    }
+    if (lsSelected != null) {
+        this._drawSingleConstellation(renderContext, lsSelected, 1);
+    }
+  }.bind(WWTControl.constellationsFigures);
 }


### PR DESCRIPTION
In the interest of not having huge updates, this PR tackles a few of the WWT issues from #2:
* Add N/S/E/W labels in the sky when the grid is on
* Add constellation figures and labels for Corona Borealis and Bootes only
* Allow toggling the constellation display in the controls box
* Move the starting location between Corona Borealis and Bootes (@patudom feel free to modify this)