### PR TITLE
Add sky annotation and update horizon with time

### DIFF
--- a/src/BlazeStarNova.vue
+++ b/src/BlazeStarNova.vue
@@ -240,6 +240,10 @@ sunPlace.set_classification(Classification.solarSystem);
 sunPlace.set_target(SolarSystemObjects.sun);
 sunPlace.set_zoomLevel(20);
 
+const crbPlace = new Place();
+crbPlace.set_RA(15 + 59 / 60 + 30.1622 / 3600);
+crbPlace.set_dec(25 + 55 / 60 + 12.613 / 3600);
+
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
 const wwtSettings: Settings = Settings.get_active();

--- a/src/BlazeStarNova.vue
+++ b/src/BlazeStarNova.vue
@@ -233,12 +233,15 @@ const positionSet = ref(false);
 const accentColor = ref("#ffffff");
 const buttonColor = ref("#ffffff");
 const tab = ref(0);
-const timePlaying = ref(true);
+const timePlaying = ref(false);
 const showHorizon = ref(true);
 const showAltAzGrid = ref(true);
 const showControls = ref(false);
 const showConstellations = ref(true);
 const crbBelowHorizon = ref(true);
+
+// For now, we're not allowing a user to change this
+const clockRate = 1000;
 
 const sunPlace = new Place();
 sunPlace.set_names(["Sun"]);
@@ -269,7 +272,8 @@ onMounted(() => {
 
     initializeConstellationNames();
 
-    store.setClockRate(1000);
+    store.setClockSync(timePlaying.value);
+    store.setClockRate(clockRate);
 
     store.applySetting(["localHorizonMode", true]);
     store.applySetting(["showAltAzGrid", showAltAzGrid.value]);
@@ -462,6 +466,8 @@ watch(showConstellations, (show) => {
   store.applySetting(["showConstellationLabels", show]);
   store.applySetting(["showConstellationFigures", show]);
 });
+
+watch(timePlaying, (play) => store.setClockSync(play));
 
 </script>
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,7 +3,7 @@ export interface LocationRad {
   latitudeRad: number;
 }
 
-export interface HorizonOptions {
+export interface HorizonSkyOptions {
   location: LocationRad;
   when?: Date;
   color?: string;


### PR DESCRIPTION
This PR ports over the sky annotation with sun-dependent opacity that we had in the eclipse stories. This also makes the horizon update with time (and based on the WWT engine location).

Built on top of #3.