### PR TITLE
Reset NSEW labels when switching Northern/Southern Hemispheres

### DIFF
--- a/src/BlazeStarNova.vue
+++ b/src/BlazeStarNova.vue
@@ -261,7 +261,7 @@ import {throttle} from './debounce';
 
 import { equatorialToHorizontal } from "./utils";
 import { EquatorialRad, LocationRad } from "./types";
-import { makeAltAzGridText, setupConstellationFigures, renderOneFrame } from "./wwt-hacks";
+import { resetAltAzGridText, makeAltAzGridText, setupConstellationFigures, renderOneFrame } from "./wwt-hacks";
 
 import { usePlaybackControl } from "./wwt_playback_control";
 import { useTimezone } from "./timezones";
@@ -480,6 +480,9 @@ const ready = computed(() => layersLoaded.value && positionSet.value);
 /* `isLoading` is a bit redundant here, but it could potentially have independent logic */
 const isLoading = computed(() => !ready.value);
 
+// It doesn't really matter which one we note here
+const inNorthernHemisphere = computed(() => selectedLocation.value.latitudeDeg > 0);
+
 function getCrbAlt(when: Date | null = null) {
   const location = getWWTLocation();
   const crbAltAz = equatorialToHorizontal(
@@ -649,6 +652,8 @@ watch(selectedLocation, (location: LocationDeg) => {
   updateCrbBelowHorizon();
   WWTControl.singleton.renderOneFrame();
 });
+
+watch(inNorthernHemisphere, (_inNorth: boolean) => resetAltAzGridText());
 
 </script>
 

--- a/src/wwt-hacks.ts
+++ b/src/wwt-hacks.ts
@@ -29,6 +29,10 @@ import {
 import { drawHorizon, drawSky } from "./horizon_sky";
 import { makeTextOverlays } from "./text";
 
+export function resetAltAzGridText() {
+  Grids._altAzTextBatch = null;
+}
+
 export function makeAltAzGridText() {
   if (Grids._altAzTextBatch == null) {
     const glyphHeight = 70;


### PR DESCRIPTION
Currently the NSEW labels are upside-down and below the horizon if the selected location is in the Southern Hemisphere (see the image below). This PR fixes that problem by remaking the labels each time the selected location switches between the N/S Hemispheres.

<img width="712" alt="Screenshot 2024-08-13 at 7 54 03 PM" src="https://github.com/user-attachments/assets/5cc62b7a-cac0-4b70-be71-a50375241730">
