### PR TITLE
Go to T CrB at 9 pm when the tour ends

### DIFF
--- a/src/BlazeStarNova.vue
+++ b/src/BlazeStarNova.vue
@@ -585,6 +585,8 @@ function onTourPlayingChange(playing: boolean) {
     store.setBackgroundImageByName("Tycho (Synthetic, Optical)");
     const time = todayAt9pm();
     selectedDate.value = time;
+    // The watcher will do this, but we need it to happen now,
+    // before we move
     store.setTime(time);
     goToTCrB(true);
   }

--- a/src/BlazeStarNova.vue
+++ b/src/BlazeStarNova.vue
@@ -576,7 +576,9 @@ function playPauseTour() {
 
 function onTourPlayingChange(playing: boolean) {
   WWTControl.singleton.renderOneFrame = playing ? originalFrameRender : newFrameRender;
-  if (!playing) {
+  if (playing) {
+    playbackControl.togglePlay();
+  } else {
     clearCurrentTour();
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore

--- a/src/BlazeStarNova.vue
+++ b/src/BlazeStarNova.vue
@@ -175,6 +175,7 @@
         <div style="flex-grow:1;"></div>
         
         <icon-button 
+          v-if="!isTourPlaying"
           :fa-icon="timePlaying ? 'pause' : 'play'"
           :color="buttonColor" 
           tooltip-text="Let time move forward"
@@ -333,6 +334,7 @@ const newFrameRender = function() {
     showHorizon.value
   );
 };
+let beforeTourTime: Date = new Date();
 
 // For now, we're not allowing a user to change this
 const clockRate = 1000;
@@ -567,6 +569,7 @@ function clearCurrentTour() {
 
 function playPauseTour() {
   if (!isTourPlaying.value) {
+    beforeTourTime = selectedDate.value;
     store.loadTour({ url: `${window.location.origin}/FindingCoronaBorealis.WTT`, play: true });
   } else {
     clearCurrentTour();
@@ -577,7 +580,7 @@ function playPauseTour() {
 function onTourPlayingChange(playing: boolean) {
   WWTControl.singleton.renderOneFrame = playing ? originalFrameRender : newFrameRender;
   if (playing) {
-    playbackControl.togglePlay();
+    playbackControl.pause();
   } else {
     clearCurrentTour();
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
@@ -585,11 +588,10 @@ function onTourPlayingChange(playing: boolean) {
     WWTControl.singleton.set__mover(null);
     store.applySetting(["localHorizonMode", true]);
     store.setBackgroundImageByName("Tycho (Synthetic, Optical)");
-    const time = todayAt9pm();
-    selectedDate.value = time;
+    selectedDate.value = beforeTourTime;
     // The watcher will do this, but we need it to happen now,
     // before we move
-    store.setTime(time);
+    store.setTime(beforeTourTime);
     goToTCrB(true);
   }
 }


### PR DESCRIPTION
This PR resolves #31. Ultimately the issue seemed to be that the view mover used in the tour doesn't go away immediately (maybe until its current motion has resolved?). I'll think about if there's a better way to handle this in WWT in general, but for here we can just remove it ourselves (`set__mover(null)`).