### PR TITLE
Replace origin with href in tour path

### DIFF
--- a/src/BlazeStarNova.vue
+++ b/src/BlazeStarNova.vue
@@ -419,6 +419,11 @@ const selectedLocation = ref<LocationDeg>({
   latitudeDeg: 42.3581,
 });
 
+let href = window.location.href;
+if (href.endsWith("/")) {
+  href = href.slice(0, href.length - 1);
+}
+
 // useTimezone also provides selectedTimezone and browserTimezone
 const { shortTimezone, selectedTimezoneOffset, browserTimezoneOffset} = useTimezone(selectedLocation);
 
@@ -607,7 +612,7 @@ function clearCurrentTour() {
 function playPauseTour() {
   if (!isTourPlaying.value) {
     beforeTourTime = selectedDate.value;
-    store.loadTour({ url: `${window.location.origin}/FindingCoronaBorealis.WTT`, play: true });
+    store.loadTour({ url: `${href}/FindingCoronaBorealis.WTT`, play: true });
   } else {
     clearCurrentTour();
     store.setBackgroundImageByName(TYCHO_ISET_NAME);


### PR DESCRIPTION
This PR is to fix a silly mistake with the tour location. We're currently using the origin instead of the full href for determining the tour path. That works locally, where the origin and href match up (which I guess is why we never noticed this), but not on the deployed app, where the tour URL is then wrong.