### PR TITLE
Use href instead of origin for glyph location

### DIFF
--- a/src/wwt-hacks.ts
+++ b/src/wwt-hacks.ts
@@ -136,9 +136,12 @@ export function useCustomGlyphs(batch: Text3dBatch) {
   batch.prepareBatch();
   const cache = batch._glyphCache;
   cache._glyphItems = {};
-  const origin = window.location.origin;
-  const imageUrl = `${origin}/glyphs2.png`;
-  const xmlUrl = `${origin}/glyphs2.xml`;
+  let href = window.location.href;
+  if (href.endsWith("/")) {
+    href = href.slice(0, href.length - 1);
+  }
+  const imageUrl = `${href}/glyphs2.png`;
+  const xmlUrl = `${href}/glyphs2.xml`;
   cache._texture = Texture.fromUrl(imageUrl);
   cache._webFile = new WebFile(xmlUrl);
   cache._webFile.onStateChange = GlyphCache.prototype._glyphXmlReady.bind(cache);


### PR DESCRIPTION
This PR fixes the same issue as #40, just for the glyph files.