### PR TITLE
separate nova sheet from use-wwt sheet, triggered by two separate buttons

### DIFF
--- a/src/BlazeStarNova.vue
+++ b/src/BlazeStarNova.vue
@@ -25,40 +25,19 @@
 
       <div id="top-content">
         <div id="left-buttons" v-if="!isTourPlaying">
-          <icon-button v-model="showTextSheet" fa-icon="book-open" :color="buttonColor"
-            :tooltip-text="showTextSheet ? 'Hide Info' : 'Learn More'" tooltip-location="start">
+          <icon-button v-model="showNovaSheet" fa-icon="book-open" :color="buttonColor"
+            :tooltip-text="showNovaSheet ? 'Hide Info' : 'Learn More'" tooltip-location="start">
+          </icon-button>
+          <icon-button v-model="showUseSheet" fa-icon="info" :color="buttonColor"
+            :tooltip-text="showUseSheet ? 'Hide Info' : 'Learn More'" tooltip-location="start">
           </icon-button>
           <!-- <icon-button v-model="showVideoSheet" fa-icon="video" :color="buttonColor" tooltip-text="Watch video"
             tooltip-location="start">
           </icon-button> -->
           
           
-          <div id="controls" class="control-icon-wrapper">
-          <div id="controls-top-row">
-            <font-awesome-icon
-              size="lg"
-              class="tab-focusable"
-              :icon="showControls ? `chevron-down` : `gear`"
-              @click="showControls = !showControls" 
-              @keyup.enter="showControls = !showControls"
-              tabindex="0" />
-          </div>
-          
-          <div v-if="showControls" id="control-checkboxes">
-            <v-checkbox :color="accentColor" v-model="showAltAzGrid" @keyup.enter="showAltAzGrid = !showAltAzGrid"
-              label="Sky Grid" hide-details />
-            <v-checkbox :color="accentColor" v-model="showHorizon" @keyup.enter="showHorizon = !showHorizon"
-              label="Horizon" hide-details />
-            <v-checkbox :color="accentColor" v-model="showConstellations" @keyup.enter="showConstellations = !showConstellations"
-              label="Constellations" hide-details />
-            <v-checkbox :color="accentColor" v-model="showBlazeOverlay" @keyup.enter="showBlazeOverlay = !showBlazeOverlay"
-              label="Blaze Star Location" hide-details />
-            <v-checkbox :color="accentColor" v-model="showAlphaOverlay" @keyup.enter="showAlphaOverlay = !showAlphaOverlay"
-              label="Alphecca Location" hide-details />
-          </div>
         </div>
-          
-        </div>
+
         <div id="center-buttons">
           <icon-button
             v-model="showLocationSelector"
@@ -66,40 +45,37 @@
             :color="buttonColor"
             tooltip-text="Select Location"
             tooltip-location="start"
-            ></icon-button>
+          ></icon-button>
 
-              <v-dialog
-                v-model="showLocationSelector"
-                max-width="fit-content"
-                transition="slide-y-transition"
-                id="eclipse-prediction-sheet"
-              >
-                <v-card>
-                    <font-awesome-icon
-                      style="position: absolute; right: 12px; top: 12px; cursor: pointer; padding: 1em; margin: -1em; z-index: 1000;"
-                      icon="square-xmark"
-                      size="xl"
-                      @click="showLocationSelector = false"
-                      @keyup.enter="showLocationSelector = false"
-                      tabindex="0"
-                      color="black"
-                    ></font-awesome-icon>
-                    <location-selector
-                      v-model="selectedLocation"
-                      />
-                    <geolocation-button
-                      :debug="false"
-                      size="30px"
-                      density="default"
-                      elevation="5"
-                      color="black"
-                      @location="selectedLocation = {longitudeDeg: $event.longitude, latitudeDeg: $event.latitude}"
-                    />
-                </v-card>
-              </v-dialog>
-                
-
-              
+          <v-dialog
+            v-model="showLocationSelector"
+            max-width="fit-content"
+            transition="slide-y-transition"
+            id="eclipse-prediction-sheet"
+          >
+            <v-card>
+              <font-awesome-icon
+                style="position: absolute; right: 12px; top: 12px; cursor: pointer; padding: 1em; margin: -1em; z-index: 1000;"
+                icon="square-xmark"
+                size="xl"
+                @click="showLocationSelector = false"
+                @keyup.enter="showLocationSelector = false"
+                tabindex="0"
+                color="black"
+              ></font-awesome-icon>
+              <location-selector
+                v-model="selectedLocation"
+                />
+              <geolocation-button
+                :debug="false"
+                size="30px"
+                density="default"
+                elevation="5"
+                color="black"
+                @location="selectedLocation = {longitudeDeg: $event.longitude, latitudeDeg: $event.latitude}"
+              />
+            </v-card>
+          </v-dialog>
         </div>
         <div id="right-buttons">
           <v-chip
@@ -124,6 +100,30 @@
             class="icon-wrapper jl_icon-button jl_debug"
             @click="() => WWTControl.singleton.renderOneFrame()"
             >Render one frame</button>
+          <div id="controls" class="control-icon-wrapper">
+            <div id="controls-top-row">
+              <font-awesome-icon
+                size="lg"
+                class="tab-focusable"
+                :icon="showControls ? `chevron-down` : `gear`"
+                @click="showControls = !showControls" 
+                @keyup.enter="showControls = !showControls"
+                tabindex="0" />
+            </div>
+          
+            <div v-if="showControls" id="control-checkboxes">
+              <v-checkbox :color="accentColor" v-model="showAltAzGrid" @keyup.enter="showAltAzGrid = !showAltAzGrid"
+                label="Sky Grid" hide-details />
+              <v-checkbox :color="accentColor" v-model="showHorizon" @keyup.enter="showHorizon = !showHorizon"
+                label="Horizon" hide-details />
+              <v-checkbox :color="accentColor" v-model="showConstellations" @keyup.enter="showConstellations = !showConstellations"
+                label="Constellations" hide-details />
+              <v-checkbox :color="accentColor" v-model="showBlazeOverlay" @keyup.enter="showBlazeOverlay = !showBlazeOverlay"
+                label="Blaze Star Location" hide-details />
+              <v-checkbox :color="accentColor" v-model="showAlphaOverlay" @keyup.enter="showAlphaOverlay = !showAlphaOverlay"
+                label="Alphecca Location" hide-details />
+            </div>
+          </div>
         </div>
       </div>
 
@@ -196,12 +196,12 @@
       <div id="bottom-content">
         <div id="date-picker">
             <v-overlay 
-            activator="parent"
-            location-strategy="connected"
-            location="top end"
-            origin="bottom end"
-            :scrim="false"
-            :style="cssVars"
+              activator="parent"
+              location-strategy="connected"
+              location="top end"
+              origin="bottom end"
+              :scrim="false"
+              :style="cssVars"
             >
             <template #activator="{props}">
               <!-- any props added are passed directly to v-card -->
@@ -253,13 +253,24 @@
         </div>
       </v-dialog>
 
-
-
-
       <!-- This dialog contains the informational content that is displayed when the book icon is clicked -->
-      <bottom-sheet
+      <bottom-nova-sheet
         :cssVars="cssVars"
-        v-model="showTextSheet"
+        v-model="showNovaSheet"
+        :accent-color="accentColor"
+        :touchscreen="touchscreen"
+        :show-blaze-overlay="showBlazeOverlay"
+        :show-alpha-overlay="showAlphaOverlay"
+        @toggle-blaze="() => store.gotoRADecZoom({ raRad: crbPlace.get_RA() * 15 * D2R, decRad: crbPlace.get_dec() * D2R, zoomDeg: 180, instant: false })"
+        @toggle-alpha="() => {
+          toggleAlpha();
+        }"
+       />
+
+      <!-- This dialog contains the informational content that is displayed when the info icon is clicked -->
+      <bottom-use-sheet
+        :cssVars="cssVars"
+        v-model="showUseSheet"
         :accent-color="accentColor"
         :touchscreen="touchscreen"
         :show-blaze-overlay="showBlazeOverlay"
@@ -292,7 +303,7 @@ import { resetAltAzGridText, makeAltAzGridText, setupConstellationFigures, rende
 import { usePlaybackControl } from "./wwt_playback_control";
 import { useTimezone } from "./timezones";
 
-type SheetType = "text" | "video";
+type SheetType = "nova-text" | "use-text" | "video";
 type CameraParams = Omit<GotoRADecZoomParams, "instant">;
 export interface MainComponentProps {
   wwtNamespace?: string;
@@ -549,7 +560,7 @@ const cssVars = computed(() => {
   // get the text-bottom-sheet id height and subtract it from 100vh
   return {
     "--accent-color": accentColor.value,
-    "--app-content-height": showTextSheet.value ? "66%" : "100%",
+    "--app-content-height": (showNovaSheet.value | showUseSheet.value) ? "66%" : "100%",
   };
 });
 
@@ -560,12 +571,21 @@ const cssVars = computed(() => {
   computed wrappers around modifying/querying that which can be used as
   dialog v-model values
 */
-const showTextSheet = computed({
+const showNovaSheet = computed({
   get() {
-    return sheet.value === "text";
+    return sheet.value === "nova-text";
   },
   set(_value: boolean) {
-    selectSheet("text");
+    selectSheet("nova-text");
+  }
+});
+
+const showUseSheet = computed({
+  get() {
+    return sheet.value === "use-text";
+  },
+  set(_value: boolean) {
+    selectSheet("use-text");
   }
 });
 

--- a/src/BlazeStarNova.vue
+++ b/src/BlazeStarNova.vue
@@ -40,6 +40,7 @@
 
         <div id="center-buttons">
           <icon-button
+            v-if="!isTourPlaying"
             v-model="showLocationSelector"
             fa-icon="location-dot"
             :color="buttonColor"
@@ -77,13 +78,7 @@
             </v-card>
           </v-dialog>
         </div>
-        <div id="right-buttons">
-          <v-chip
-            v-if="crbBelowHorizon && !isTourPlaying"
-            class="chip-text"
-          >
-            Corona Borealis is Set
-          </v-chip>
+        <div id="right-buttons" v-if="!isTourPlaying">
           <button 
             class="icon-wrapper jl_icon-button jl_debug" 
             @click="() => updateHorizonAndSky()"
@@ -124,6 +119,12 @@
                 label="Alphecca Location" hide-details />
             </div>
           </div>
+          <v-chip
+            v-if="crbBelowHorizon"
+            class="chip-text"
+          >
+            Corona Borealis is Set
+          </v-chip>
         </div>
       </div>
 

--- a/src/BottomNovaSheet.vue
+++ b/src/BottomNovaSheet.vue
@@ -1,0 +1,208 @@
+<template>
+  <v-dialog :style="cssVars" class="bottom-sheet" id="text-bottom-sheet" hide-overlay persistent no-click-animation
+  absolute width="100%" :scrim="false" location="bottom" v-model="showNovaSheet"
+  transition="dialog-bottom-transition">
+    <v-card id="bottom-sheet-card" height="100%">
+      <font-awesome-icon id="close-text-icon" class="control-icon" icon="times" size="lg"
+        @click="showNovaSheet = false" @keyup.enter="showNovaSheet = false" tabindex="0">
+      </font-awesome-icon>
+      <v-card-text class="info-text tab-items no-bottom-border-radius scrollable">
+        <h3
+          style="margin-bottom: 10px;"
+        >The Blaze Star Nova</h3>
+        <p>You may have heard that a star in our night sky is going to "go nova" soon. Learn what this means and how you can see the nova!</p>
+        <h4>What is a nova?</h4>
+        <p>
+          Novas are bright stars that seem to appear out of nowhere. They are named for the Latin word for "new." In reality, stars that "go nova" have been there the whole time, but they did not not appear very bright, and therefore were not obvious in the sky. An explosion of gas on the surface of the star (the nova event) temporarily makes the star much, <strong>MUCH</strong> brighter than it was before.
+        </p>
+        <h4>How do I see this nova?</h4>
+        <p>
+          The star that will become a nova is named "T Coronae Borealis." It is often referred to as "T CrB" for short and is also nicknamed the "Blaze Star" (Go to <a href="#" @click.prevent="$emit('toggle-blaze')">T CrB</a>). As the name suggests, it is located within the constellation Corona Borealis, the "Northern Crown." <a href="#" onclick="return false;" @click="() => playTour()">This guide</a> explains how you can find Corona Borealis in your night sky.
+        </p>
+        <!-- <v-btn @click="$emit('toggle-blaze')">{{ `${showBlazeOverlay ? 'Hide' : 'Show'} T CrB label` }}</v-btn> -->
+        <p>
+          On a clear night, go out and look for Corona Borealis, so you can get used to its U-shape in the sky. Once T CrB goes nova, which can be any day now, or possibly weeks or months from now, it will seem as if a new star appeared just to the lower left of the U shape of the constellation.
+        </p>
+        <h4>How bright will the nova be?</h4>
+        <p>
+          At its normal brightness, T CrB is about a 10th magnitude star. This is about 30-40 times fainter than the faintest star a person could see from a dark sky, so you would need a telescope to see it. When it goes nova, it is predicted to be about 2-2.5 magnitudes. It is comparable in brightness to Alphecca (Go to <a href="#" @click.prevent="$emit('toggle-alpha')">Alphecca</a>), the brightest star you can see in the crown of Corona Borealis.
+        </p>
+        <!-- <v-btn @click="$emit('toggle-alpha')">{{ `${showAlphaOverlay ? 'Hide' : 'Show'} alpha label` }}</v-btn> -->
+        <h4>What causes a nova?</h4>
+        <p>
+          Novas occur in binary star systems where small, very dense, very hot stars called white dwarfs orbit another large star at close range. The gravitational pull from the white dwarf can pull gas from the outer layers of the large companion star onto the surface of the white dwarf. When enough of this gas collects on the surface of the white dwarf, it triggers a nuclear explosion that causes the temporary brightening of the nova.
+        </p>
+        
+        <figure class="fig-right" style="width:40%;"> <!-- floats, the old magic, before flex-->
+          <v-img
+            src="https://www.nasa.gov/wp-content/uploads/2024/06/novacyg093500952-print.jpg"
+          ></v-img>
+          <figcaption>A red giant star and white dwarf orbit each other, similar to T Coronae Borealis, the Blaze Star. 
+            A disk of material is pulled off the red giant, into a disk, and then onto the white dwarf. (Credit: NASA / Goddard Space Flight Center)
+          </figcaption>
+        </figure>
+        
+        <h4>How do we know this nova is getting ready to blow?</h4>
+        <p>
+          Luckily, novas only blow up the gas that has settled on the surface of the white dwarf, and NOT the white dwarf itself. This means that the white dwarf can pull a new round of gas from its companion star. In some nova systems, this cycle of collecting gas, going nova, collecting more gas, going nova again, happens at a repeatable timescale. For T CrB, this has happened roughly every 80 years. It last blew in 1946, and before that, it blew in 1866. Astronomers have observed changes in the star's overall brightness that suggest it is getting ready to go nova again soon!
+        </p>
+        <h4>Why does this star have multiple names?</h4>
+        <p>
+          Astronomers usually name stars for the constellation they are in, and approximately for the relative brightness within the constellation, as designated by Greek letters. For example, the brightest star in Corona Borealis, Alphecca, is also known as &#945;-CrB. The 2nd brightest star is &#946;-CrB. 
+        </p>
+        <p>
+          The astronomer Friedrich Argelander began the practice of assigning Roman letters to stars that vary in brightness, beginning with the letter R. So the "T" in T CrB means that it is the third variable star discovered within Corona Borealis.
+        </p>
+        <p>
+          The nickname "Blaze Star" was given to T CrB after it "blazed forth suddenly" on May 12, 1866, becoming as bright as Alphecca. Learn more about the history in this 1897 <a href="https://articles.adsabs.harvard.edu/pdf/1897PA......5...97P" target="_blank"
+          rel="noopener noreferrer">article</a>, <em>Heavens for June</em> (see section "The Northern Crown"), by Mary Proctor.
+        </p>
+      </v-card-text>
+    </v-card>
+  </v-dialog>
+</template>
+
+
+<script setup lang="ts">
+import { defineProps, defineEmits, withDefaults, defineModel, watch, ref } from 'vue';
+import { engineStore } from "@wwtelescope/engine-pinia";
+
+export interface Props {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  cssVars?: any;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  accentColor?: any;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  touchscreen?: any;
+  showBlazeOverlay: boolean;
+  showAlphaOverlay: boolean;
+}
+
+const props = withDefaults(defineProps<Props>(),{
+  cssVars: () => ({}),
+  accentColor: () => 'accent',
+  touchscreen: () => false,
+  showBlazeOverlay: false,
+  showalphaOverlay: false,
+});
+
+const emits = defineEmits(['close', 'toggle-blaze', 'toggle-alpha']);
+
+const { cssVars, accentColor, touchscreen } = props;
+
+const tab = ref(0);
+
+const showNovaSheet = defineModel({default: true});
+
+const store = engineStore();
+
+function playTour() {
+  store.loadTour({ url: `${window.location.origin}/FindingCoronaBorealis.WTT`, play: true });
+}
+
+watch(() => showNovaSheet, (newVal) => {
+  if (!newVal) {
+    emits('close');
+  }
+});
+
+</script>
+
+<style lang="less">
+
+.bottom-sheet {
+  .v-overlay__content {
+    align-self: flex-end;
+    padding: 0;
+    margin: 0;
+    max-width: 100%;
+    height: 34%;
+  }
+
+  #tabs {
+    width: calc(100% - 3em);
+    align-self: left;
+  }
+  
+  .info-tabs {
+    border-bottom: 2px solid var(--accent-color);
+  }
+
+  .info-text {
+    height: 33vh;
+    padding-bottom: 25px;
+
+    & a {
+      text-decoration: none;
+    }
+  }
+
+  .close-icon {
+    position: absolute;
+    top: 10px;
+    right: 10px;
+    z-index: 15;
+
+    &:hover {
+      cursor: pointer;
+    }
+
+    &:focus {
+      color: white;
+      border: 2px solid white;
+    }
+  }
+
+  .scrollable {
+    overflow-y: auto;
+  }
+
+
+
+  #bottom-sheet-card .tab-items.v-card-text {
+    font-size: ~"max(14px, calc(0.7em + 0.3vw))";
+    padding-top: ~"max(2vw, 16px)";
+    padding-left: ~"max(4vw, 16px)";
+    padding-right: ~"max(4vw, 16px)";
+
+    .end-spacer {
+      height: 25px;
+    }
+  }
+
+
+  #close-text-icon {
+    position: absolute;
+    top: 0.25em;
+    right: calc((3em - 0.6875em) / 3); // font-awesome-icons have width 0.6875em
+    color: white;
+  }
+
+  // This prevents the tabs from having some extra space to the left when the screen is small
+  // (around 400px or less)
+  .v-tabs:not(.v-tabs--vertical).v-tabs--right>.v-slide-group--is-overflowing.v-tabs-bar--is-mobile:not(.v-slide-group--has-affixes) .v-slide-group__next,
+  .v-tabs:not(.v-tabs--vertical):not(.v-tabs--right)>.v-slide-group--is-overflowing.v-tabs-bar--is-mobile:not(.v-slide-group--has-affixes) .v-slide-group__prev {
+    display: none;
+  }
+}
+
+figure {
+  padding: 0.5em;
+  margin: 1em;
+  background-color: #151515;
+}
+
+.fig-right {
+  float: right;
+}
+
+.fig-left {
+  float: left;
+}
+
+figcaption {
+  font-size: 0.8em;
+  color: #ccc;
+}
+
+</style>

--- a/src/BottomNovaSheet.vue
+++ b/src/BottomNovaSheet.vue
@@ -64,7 +64,7 @@
 
 
 <script setup lang="ts">
-import { defineProps, defineEmits, withDefaults, defineModel, watch, ref } from 'vue';
+import { defineProps, defineEmits, withDefaults, defineModel, watch } from 'vue';
 import { engineStore } from "@wwtelescope/engine-pinia";
 
 export interface Props {
@@ -88,9 +88,7 @@ const props = withDefaults(defineProps<Props>(),{
 
 const emits = defineEmits(['close', 'toggle-blaze', 'toggle-alpha']);
 
-const { cssVars, accentColor, touchscreen } = props;
-
-const tab = ref(0);
+const { cssVars } = props;
 
 const showNovaSheet = defineModel({default: true});
 

--- a/src/BottomUseSheet.vue
+++ b/src/BottomUseSheet.vue
@@ -67,8 +67,7 @@
 
 
 <script setup lang="ts">
-import { defineProps, defineEmits, withDefaults, defineModel, watch, ref } from 'vue';
-import { engineStore } from "@wwtelescope/engine-pinia";
+import { defineProps, defineEmits, withDefaults, defineModel, watch } from 'vue';
 
 export interface Props {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -91,17 +90,9 @@ const props = withDefaults(defineProps<Props>(),{
 
 const emits = defineEmits(['close', 'toggle-blaze', 'toggle-alpha']);
 
-const { cssVars, accentColor, touchscreen } = props;
-
-const tab = ref(0);
+const { cssVars, touchscreen } = props;
 
 const showUseSheet = defineModel({default: true});
-
-const store = engineStore();
-
-function playTour() {
-  store.loadTour({ url: `${window.location.origin}/FindingCoronaBorealis.WTT`, play: true });
-}
 
 watch(() => showUseSheet, (newVal) => {
   if (!newVal) {

--- a/src/BottomUseSheet.vue
+++ b/src/BottomUseSheet.vue
@@ -1,0 +1,211 @@
+<template>
+  <v-dialog :style="cssVars" class="bottom-sheet" id="text-bottom-sheet" hide-overlay persistent no-click-animation
+  absolute width="100%" :scrim="false" location="bottom" v-model="showUseSheet"
+  transition="dialog-bottom-transition">
+    <v-card id="bottom-sheet-card" height="100%">
+      <font-awesome-icon id="close-text-icon" class="control-icon" icon="times" size="lg"
+        @click="showUseSheet = false" @keyup.enter="showUseSheet = false" tabindex="0">
+      </font-awesome-icon>
+      <v-card-text class="info-text tab-items no-bottom-border-radius scrollable">
+        <h3>How to Use WWT</h3>
+        <v-container>
+          <v-row align="center">
+            <v-col cols="4">
+              <v-chip label outlined>
+                Pan
+              </v-chip>
+            </v-col>
+            <v-col cols="8" class="pt-1">
+              <strong>{{ touchscreen ? "press + drag" : "click + drag" }}</strong> {{ touchscreen ? ":" : "or"
+              }} <strong>{{ touchscreen ? ":" : "W-A-S-D" }}</strong> {{ touchscreen ? ":" : "keys" }}<br>
+            </v-col>
+          </v-row>
+          <v-row align="center">
+            <v-col cols="4">
+              <v-chip label outlined>
+                Zoom
+              </v-chip>
+            </v-col>
+            <v-col cols="8" class="pt-1">
+              <strong>{{ touchscreen ? "pinch in and out" : "scroll in and out" }}</strong> {{ touchscreen ? ":"
+                : "or" }} <strong>{{ touchscreen ? ":" : "I-O" }}</strong> {{ touchscreen ? ":" : "keys" }}<br>
+            </v-col>
+          </v-row>
+          <v-row>
+            <v-col cols="12">
+              <div class="credits">
+                <h3>Credits:</h3>
+                <h4><a href="https://www.cosmicds.cfa.harvard.edu/" target="_blank"
+                    rel="noopener noreferrer">CosmicDS</a> Vue Data Stories Team:</h4>
+                John Lewis<br>
+                Jon Carifio<br>
+                Pat Udomprasert<br>
+                Alyssa Goodman<br>
+                Mary Dussault<br>
+                Harry Houghton<br>
+                Anna Nolin<br>
+                Evaluator: Sue Sunbury<br>
+                <br>
+                <h4>WorldWide Telescope Team:</h4>
+                Peter Williams<br>
+                A. David Weigel<br>
+                Jon Carifio<br>
+              </div>
+              <v-spacer class="end-spacer"></v-spacer>
+            </v-col>
+          </v-row>
+          <v-row>
+            <v-col>
+              <funding-acknowledgement />
+            </v-col>
+          </v-row>
+        </v-container>
+      </v-card-text>
+    </v-card>
+  </v-dialog>
+</template>
+
+
+<script setup lang="ts">
+import { defineProps, defineEmits, withDefaults, defineModel, watch, ref } from 'vue';
+import { engineStore } from "@wwtelescope/engine-pinia";
+
+export interface Props {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  cssVars?: any;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  accentColor?: any;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  touchscreen?: any;
+  showBlazeOverlay: boolean;
+  showAlphaOverlay: boolean;
+}
+
+const props = withDefaults(defineProps<Props>(),{
+  cssVars: () => ({}),
+  accentColor: () => 'accent',
+  touchscreen: () => false,
+  showBlazeOverlay: false,
+  showalphaOverlay: false,
+});
+
+const emits = defineEmits(['close', 'toggle-blaze', 'toggle-alpha']);
+
+const { cssVars, accentColor, touchscreen } = props;
+
+const tab = ref(0);
+
+const showUseSheet = defineModel({default: true});
+
+const store = engineStore();
+
+function playTour() {
+  store.loadTour({ url: `${window.location.origin}/FindingCoronaBorealis.WTT`, play: true });
+}
+
+watch(() => showUseSheet, (newVal) => {
+  if (!newVal) {
+    emits('close');
+  }
+});
+
+</script>
+
+<style lang="less">
+
+.bottom-sheet {
+  .v-overlay__content {
+    align-self: flex-end;
+    padding: 0;
+    margin: 0;
+    max-width: 100%;
+    height: 34%;
+  }
+
+  #tabs {
+    width: calc(100% - 3em);
+    align-self: left;
+  }
+  
+  .info-tabs {
+    border-bottom: 2px solid var(--accent-color);
+  }
+
+  .info-text {
+    height: 33vh;
+    padding-bottom: 25px;
+
+    & a {
+      text-decoration: none;
+    }
+  }
+
+  .close-icon {
+    position: absolute;
+    top: 10px;
+    right: 10px;
+    z-index: 15;
+
+    &:hover {
+      cursor: pointer;
+    }
+
+    &:focus {
+      color: white;
+      border: 2px solid white;
+    }
+  }
+
+  .scrollable {
+    overflow-y: auto;
+  }
+
+
+
+  #bottom-sheet-card .tab-items.v-card-text {
+    font-size: ~"max(14px, calc(0.7em + 0.3vw))";
+    padding-top: ~"max(2vw, 16px)";
+    padding-left: ~"max(4vw, 16px)";
+    padding-right: ~"max(4vw, 16px)";
+
+    .end-spacer {
+      height: 25px;
+    }
+  }
+
+
+  #close-text-icon {
+    position: absolute;
+    top: 0.25em;
+    right: calc((3em - 0.6875em) / 3); // font-awesome-icons have width 0.6875em
+    color: white;
+  }
+
+  // This prevents the tabs from having some extra space to the left when the screen is small
+  // (around 400px or less)
+  .v-tabs:not(.v-tabs--vertical).v-tabs--right>.v-slide-group--is-overflowing.v-tabs-bar--is-mobile:not(.v-slide-group--has-affixes) .v-slide-group__next,
+  .v-tabs:not(.v-tabs--vertical):not(.v-tabs--right)>.v-slide-group--is-overflowing.v-tabs-bar--is-mobile:not(.v-slide-group--has-affixes) .v-slide-group__prev {
+    display: none;
+  }
+}
+
+figure {
+  padding: 0.5em;
+  margin: 1em;
+  background-color: #151515;
+}
+
+.fig-right {
+  float: right;
+}
+
+.fig-left {
+  float: left;
+}
+
+figcaption {
+  font-size: 0.8em;
+  color: #ccc;
+}
+
+</style>

--- a/src/main.ts
+++ b/src/main.ts
@@ -9,6 +9,9 @@ import vuetify from "../plugins/vuetify";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 
 import BottomSheet from "./BottomSheet.vue";
+import BottomNovaSheet from "./BottomNovaSheet.vue";
+import BottomUseSheet from "./BottomUseSheet.vue";
+
 import SplashScreen from "./SplashScreen.vue";
 import VueDatePicker from '@vuepic/vue-datepicker';
 import '@vuepic/vue-datepicker/dist/main.css';
@@ -24,6 +27,7 @@ import {
   faChevronDown,
   faClock,
   faGear,
+  faInfo,
   faLocation,
   faLocationDot,
   faPlay,
@@ -38,6 +42,7 @@ library.add(faBookOpen);
 library.add(faChevronDown);
 library.add(faClock);
 library.add(faGear);
+library.add(faInfo);
 library.add(faLocation);
 library.add(faLocationDot);
 library.add(faPause);
@@ -79,6 +84,8 @@ createApp(BlazeStarNova, {
   .component("WorldWideTelescope", WWTComponent)
   .component('font-awesome-icon', FontAwesomeIcon)
   .component('bottom-sheet', BottomSheet)
+  .component('bottom-nova-sheet', BottomNovaSheet)
+  .component('bottom-use-sheet', BottomUseSheet)
   .component('icon-button', IconButton)
   .component('funding-acknowledgement', FundingAcknowledgement)
   .component('credit-logos', CreditLogos)


### PR DESCRIPTION
The two elements are called BottomNovaSheet and BottomUseSheet. The original BottomSheet that combined the two and had tabs remains as an element, but is not included in the blaze-star-nova.vue code. Also, an "i" icon has been added to represent the wwt-usage sheet. There has also been some adjustments to the tabbing of the code for readability.