### PR TITLE
Change rating timeout back to 40 seconds

### DIFF
--- a/src/BlazeStarNova.vue
+++ b/src/BlazeStarNova.vue
@@ -803,7 +803,7 @@ async function ratingDisplaySetup() {
   }
   setTimeout(() => {
     showRating.value = true; 
-  }, 1_000);
+  }, 40_000);
 }
 
 function updateUserExperienceInfo(rating: UserExperienceRating | null, comments: string | null) {


### PR DESCRIPTION
The rating display timer is still set to 1 second from some debugging. This PR changes it back to 40 seconds.